### PR TITLE
Standardize from HubActions to Strings

### DIFF
--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -143,7 +143,7 @@ metadata {
         command "setSchedule", ["number","number","number","number","number","number"]
         command "resetSchedule", ["number","number"]
         command "setVSPSpeeds"
-//        command "updated"
+        command "updated"
         
 		fingerprint deviceId: "0x1001", inClusters: "0x91,0x73,0x72,0x86,0x81,0x60,0x70,0x85,0x25,0x27,0x43,0x31", outClusters: "0x82"
 	}

--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -1834,15 +1834,15 @@ def List addRefreshCmds(List cmds)  {
 
 // Called by switch presses on the circuit buttons.
 def List on1()  { delayBetweenLog(addRefreshCmds(setChanState(1, 0xFF))) }
-def List on2()  { delayBetweenLog(addRefreshCmds(setChanState(2, 0xFF))) }
+def List on2()  { delayBetweenLog(addRefreshCmds(setChanStateAndGet(2, 0xFF))) }
 def List on3()  { delayBetweenLog(addRefreshCmds(setChanState(3, 0xFF))) }
 def List on4()  { delayBetweenLog(addRefreshCmds(setChanState(4, 0xFF))) }
-def List on5()  { delayBetweenLog(addRefreshCmds(setChanState(5, 0xFF))) }
+def List on5()  { delayBetweenLog(addRefreshCmds(setChanStateAndGet(5, 0xFF))) }
 def List off1() { delayBetweenLog(addRefreshCmds(setChanState(1, 0))) }
-def List off2() { delayBetweenLog(addRefreshCmds(setChanState(2, 0))) }
+def List off2() { delayBetweenLog(addRefreshCmds(setChanStateAndGet(2, 0))) }
 def List off3() { delayBetweenLog(addRefreshCmds(setChanState(3, 0))) }
 def List off4() { delayBetweenLog(addRefreshCmds(setChanState(4, 0))) }
-def List off5() { delayBetweenLog(addRefreshCmds(setChanState(5, 0))) }
+def List off5() { delayBetweenLog(addRefreshCmds(setChanStateAndGet(5, 0))) }
 
 // May be called by CoRE
 def List setVSPSpeed(sp)       {delayBetweenLog(addRefreshCmds(setVSPSpeedInternal(sp))) }

--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -642,7 +642,7 @@ def parse(String description) {
             command = command1.split(',')[0]
             payloadStr = description.split('payload:')[1]
             } catch (e) {
-                log.warn("..... Exception in Parse() ${cmd} - description:${description} exceptioon ${e}")
+                log.warn("..... Exception in Parse() ${cmd} - description:${description} exception ${e}")
             }
         //			log.debug "command: ${command}   payloadStr: ${payloadStr}"
         if (command.contains("9100")) {

--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -147,6 +147,7 @@ metadata {
         command "resetSchedule", ["number","number"]
         command "setVSPSpeeds"
         command "updated"
+		command "recreateChildren"
         
 		fingerprint deviceId: "0x1001", inClusters: "0x91,0x73,0x72,0x86,0x81,0x60,0x70,0x85,0x25,0x27,0x43,0x31", outClusters: "0x82"
 	}
@@ -1272,6 +1273,14 @@ def List updated() {
 	sendHubCommand(cmds,0)
 //	log.debug devStr
     return []
+}
+
+def recreateChildren() {
+	log.trace("+++++ recreateChildren")
+	def children = getChildDevices()
+	log.trace("----- recreateChildren - deleting ${children}")
+	removeChildDevices(children)
+	createChildDevices()
 }
 
 def List configure() {

--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -1704,9 +1704,9 @@ def setMode(int mode) {
 private List getRefreshCmds() {
 //	log.debug "+++++ getRefreshCmds"
 	def cmds =[
-		new hubitat.device.HubAction("910005400102870301"),
-		new hubitat.device.HubAction("910005400101830101"),
-//		new hubitat.device.HubAction("91000541010100"),
+		"910005400102870301",
+		"910005400101830101",
+//		"91000541010100",
 	]
 	cmds
 }

--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -64,7 +64,7 @@
  *	3.06	08/30/2018	KeithR26	Make temperature events visible
  *									Suppress redundant events
 */
-def getVERSION () {"Ver 3.06"}		// Keep track of handler version
+def getVERSION () {"Ver 3.07"}		// Keep track of handler version
 
 metadata {
 	definition (name: "Intermatic Pool Control System", author: "KeithR26", namespace:  "KeithR26") {

--- a/intermatic-pe653-pool-control-system.groovy
+++ b/intermatic-pe653-pool-control-system.groovy
@@ -63,11 +63,14 @@
  *									Fix Light Color slider
  *	3.06	08/30/2018	KeithR26	Make temperature events visible
  *									Suppress redundant events
+ *  3.07	10/xx/2018  Tooluser    Standardize on strings rather than HubActions
+ *                                  Standardize logging
+ *.                                 Add event for forcing deletion and recreation of child devices
 */
-def getVERSION () {"Ver 3.07"}		// Keep track of handler version
+def getVERSION () {"Ver 3.07a"}
 
 metadata {
-	definition (name: "Intermatic Pool Control System", author: "KeithR26", namespace:  "KeithR26") {
+	definition (name: "Intermatic Pool Control System", author: "tooluser", namespace:  "KeithR26") {
         capability "Actuator"
 		capability "Switch"
 		capability "Polling"


### PR DESCRIPTION
# Purpose
The DTH is currently not working. Take some advice from various people in the thread to attempt a fix. 

# Implementation Details
- Per @chuck.schwer, don't mix `String`s and `HubAction`s. Standardize here on Strings.
  - (I'd love to constant-ize these strings, but I don't know what they mean)
- Standardize logging by using log levels rather than conditionals
  - This may not be working, so I may introduce a `_log` method to DRY up that behavior
- Make SmartThings/Hubitat condition code-based so no code need be commented out
- May attempt to upgrade to new namespace for the child switches (`iNovelli`)
- Attempt to simplify child-creation code and move to `initialize`